### PR TITLE
Add CODEOWNERS for @amboss-mededu/library-experience

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @amboss-mededu/library-experience
+* @amboss-mededu/library-experience kniggishood

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @amboss-mededu/library-experience

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @amboss-mededu/library-experience kniggishood
+* @amboss-mededu/library-experience @kniggishood


### PR DESCRIPTION
This PR adds a `.github/CODEOWNERS` file assigning `@amboss-mededu/library-experience` as the default owner.