### PR TITLE
docs: refresh README and FAQ for v2

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,48 +1,61 @@
 # FAQ
 
-## TL;DR;
-**Was ist es?** Eine schnelle AMBOSS-Suchbox auf dem Desktop.  
-**Wie funktioniert's?** Hotkeys nutzen (CMD + J für Mac, Ctrl + J für Windows) für direkten Zugriff.  
-**Features:** Automatische Suchvorschläge, schnelle Artikel, ggf. bald Checklisten und Laborwerte auflisten  
-**Download & Installation:** Einfach, mit Autostart-Option. Verfügbar auf [GitHub](https://github.com/amboss-mededu/ambulaunch-beta-releases).  
-**Benutzung:** Einloggen einmalig erforderlich, bleibt lange aktiv. Icons im Blick behalten für schnellen Zugriff.  
-**Bugs:** Kleine Ruckler, Probleme mit externen Monitoren.
+## TL;DR
+**Was ist es?** Ein Desktop-Launcher für die AMBOSS-Plattform mit Such-Hotkey.  
+**Wie funktioniert's?** Hotkey nutzen (`Cmd + J` für macOS, `Strg + J` für Windows) für direkten Zugriff — frei umbelegbar in den Einstellungen.  
+**Features:** Suche, KI-Modus (Ask), schwebendes Logo, Deutsch/Englisch, automatische Updates.  
+**Download & Installation:** Einfach, mit Autostart-Option. Verfügbar im [Releases-Bereich auf GitHub](https://github.com/amboss-mededu/ambulaunch-beta-releases/releases/latest).  
+**Benutzung:** Einloggen einmalig erforderlich, bleibt lange aktiv.
 
 ## Willkommen bei Ambulaunch!
-Ein intuitiver Launcher für die AMBOSS-Plattform, der den Zugriff auf medizinische Bildungsressourcen vereinfacht.
+Ein intuitiver Launcher für die AMBOSS-Plattform, der den Zugriff auf medizinische Inhalte vereinfacht.
 
-## Hauptfunktionen:
-- **Sofortzugriff:** Mit Hotkey (CMD + J für Mac, Ctrl + J für Windows) direkt zur Suchbox.
-- **Effiziente Suche:** Automatische Vorschläge und schnelle Antworten speziell für medizinische Fachgebiete.
-
-### Extras:
-- Individuelle Inhaltsvorschläge und schnelle Hilfefunktionen, wie z.B. das Anzeigen von Laborwerten oder Checklisten.
+## Hauptfunktionen
+- **Sofortzugriff:** Mit Hotkey (`Cmd + J` für macOS, `Strg + J` für Windows) direkt zur Suchbox — frei umbelegbar.
+- **Effiziente Suche:** Automatische Vorschläge und schnelle Antworten, speziell für medizinische Fachgebiete.
+- **KI-Modus (Ask):** Eine medizinische Frage stellen und eine kuratierte, kontextuelle Antwort erhalten.
 
 ## Erste Schritte
 ![Ambulaunch Demo](ambulaunch-demo.gif)
 
 ## Download
-Die Download-Dateien sind [hier](https://github.com/amboss-mededu/ambulaunch-beta-releases) öffentlich zugänglich. Die jeweils aktuellste Version findet sich im Abschnitt Download.
+Die Download-Dateien sind im [Releases-Bereich](https://github.com/amboss-mededu/ambulaunch-beta-releases/releases/latest) öffentlich zugänglich. Dort jeweils die zur Plattform passende Datei auswählen.
 
 ## Installation
-Installation wie von anderen Anwendungen bekannt. **Ambulaunch** wird außerdem in den Autostart installiert, sodass es bei Neustarts automatisch startet.  
-Wenn das nicht erwünscht ist:
-- [Anleitung für Windows](https://support.microsoft.com/de-de/windows/festlegen-dass-apps-automatisch-ausgef%C3%BChrt-werden-wenn-sie-ihr-ger%C3%A4t-starten-a5b64b3e-4483-4dad-abc7-027a863e1c2e#)
+Installation wie von anderen Anwendungen bekannt. **Ambulaunch** wird außerdem in den Autostart aufgenommen, sodass es bei jedem Login automatisch bereitsteht.
+
+Falls nicht gewünscht, lässt sich der Autostart abschalten — entweder direkt in den Ambulaunch-Einstellungen (Tray-Icon → Einstellungen → Allgemein → **Beim Anmelden starten**) oder über die Systemeinstellungen:
+- [Anleitung für Windows](https://support.microsoft.com/de-de/windows/festlegen-dass-apps-automatisch-ausgef%C3%BChrt-werden-wenn-sie-ihr-ger%C3%A4t-starten-a5b64b3e-4483-4dad-abc7-027a863e1c2e)
 - [Anleitung für Mac](https://support.apple.com/de-de/guide/mac-help/mh21210/mac)
 
-## Einrichtung
-### Sichtbarkeit
-Wir empfehlen, die Desktop-Suche so einzustellen, dass zu jeder Zeit ein kleines AMBOSS-Logo zu sehen ist. Dazu wie folgt vorgehen:
-- **Bei Mac:** Rechtsklick auf das AMBOSS-Icon in der Menüleiste oben rechts im Bild
-- **Bei Windows:** Rechtsklick auf das AMBOSS-Icon in der Taskleiste/Benachrichtigungsbereich, i.d.R. unten rechts im Bild. Wenn nicht zu sehen, Klick auf den Pfeil um “Weitere anzuzeigen”
+## Hotkey ändern
+Standardmäßig öffnet sich Ambulaunch mit `Cmd + J` (macOS) bzw. `Strg + J` (Windows). Eine andere Tastenkombination lässt sich festlegen über Tray-Icon → **Tastenkürzel** → **Tastenkürzel ändern** oder in den Einstellungen unter **Allgemein → Tastenkürzel**.
 
-Danach, falls nicht schon aktiv, das Item “Immer anzeigen” aktivieren. Dadurch erscheint auf dem Bildschirm ein AMBOSS-Logo, das sich verschieben und anklicken lässt.
+## Schwebendes Logo
+Wir empfehlen, das schwebende AMBOSS-Logo auf dem Desktop zu aktivieren, damit Ambulaunch auch ohne Hotkey jederzeit erreichbar bleibt. Aktivierung über Tray-Icon → **Schwebendes Logo anzeigen** oder Einstellungen → Allgemein. Das Logo lässt sich frei platzieren und merkt sich seine Position über Neustarts hinweg.
+
+## Sprache umstellen
+Ambulaunch unterstützt Deutsch und Englisch. Umschaltung über Tray-Icon → **Sprache** oder Einstellungen → Allgemein → **Sprache**. Ein Neustart der App schließt die Umstellung ab.
 
 ## Benutzen
-Die Suche lässt sich nun über Strg/Cmd + J oder über Klick auf das Amboss-Logo aufrufen. Suchbegriff eingeben und über Pfeiltasten, Klick oder Enter die Suche wie im Webbrowser ausführen. Die Suchbox kann über einen Klick an anderer Stelle wieder minimiert werden und über den Hotkey oder Klick aufs Icon eine erneute Suche gestartet werden.
+Die Suche lässt sich nun über den Hotkey oder per Klick auf das schwebende Logo aufrufen. Suchbegriff eingeben und über Pfeiltasten, Klick oder Enter die Suche ausführen, wie aus dem Webbrowser bekannt. Die Suchbox kann durch Klick an anderer Stelle minimiert und über den Hotkey jederzeit wieder aufgerufen werden.
 
 ## Einloggen
-**Ambulaunch** ruft einen eigenen Mini-Browser auf. Dadurch wird beim ersten(!) Aufrufen zum Einloggen aufgerufen. Solange der Nutzer nicht abgemeldet wird, bleibt die Sitzung lange aktiv, ohne dass ein erneutes Anmelden erforderlich ist.
+**Ambulaunch** ruft beim ersten Start einen integrierten Mini-Browser zur AMBOSS-Anmeldung auf. Solange der Nutzer nicht abgemeldet wird, bleibt die Sitzung anschließend langfristig aktiv, ohne dass eine erneute Anmeldung erforderlich ist.
 
-## Bekannte Bugs
-- Probleme bei Verwendung mit wechselnden externen Monitoren
+## Updates
+Ambulaunch aktualisiert sich automatisch im Hintergrund. Sobald eine neue Version installiert ist, erscheint ein Dialog für den Neustart.
+
+Wer Updates frühzeitig testen möchte, kann unter **Einstellungen → Updates → Pre-Release-Versionen** den Pre-Release-Kanal aktivieren.
+
+## KI-Modus (Ask)
+Im Eingabefenster oben zwischen **Suche** und **KI-Modus** wechseln. Im KI-Modus eine medizinische Frage formulieren — Ambulaunch liefert eine kontextuelle Antwort auf Basis kuratierter AMBOSS-Inhalte.
+
+## Datenschutz
+Suchanfragen werden zur Verarbeitung an die AMBOSS-Plattform übermittelt — wie auch beim normalen Browserzugriff. Darüber hinaus sendet die App eine anonyme Geräte-ID zur Stabilitäts- und Nutzungsmessung. Diese ID lässt sich keiner Person zuordnen.
+
+## Ambulaunch Pro
+Für erweiterte Funktionen — Spracheingabe, lokale KI-Modelle, OCR — gibt es **Ambulaunch Pro** für Kliniken und Praxen. Anfragen an **hallo@amboss.com**.
+
+## Bekannte Einschränkungen und Probleme melden
+Bekannte Bugs und Limitationen werden in den jeweiligen [Release Notes](https://github.com/amboss-mededu/ambulaunch-beta-releases/releases) dokumentiert. Fehler oder Verbesserungswünsche bitte per E-Mail an **hallo@amboss.com**.

--- a/README.md
+++ b/README.md
@@ -1,47 +1,45 @@
-# 🚀 Ambulaunch-Beta Release Repo
+# 🚀 Ambulaunch Release Repository
 
-Willkommen zum Ambulaunch BETA Release Repository! Ambulaunch ist ein einfach zu bedienender, leistungsstarker Launcher, der speziell für den Einsatz in Arztpraxen und Kliniken entwickelt wurde. Dieses Tool hilft, effizienter zu arbeiten, indem es nahtlosen Zugriff auf eine breite Palette von klinischen, medizinischen Ressourcen bietet ohne dabei viele Klicks zu erfordern.
+Willkommen zum Ambulaunch Release Repository! Ambulaunch ist ein einfach zu bedienender, leistungsstarker Launcher, der speziell für den Einsatz in Arztpraxen und Kliniken entwickelt wurde. Dieses Tool hilft, effizienter zu arbeiten, indem es nahtlosen Zugriff auf eine breite Palette von klinischen Ressourcen bietet — ohne dabei viele Klicks zu erfordern.
 
-[Zum FAQ](https://gist.github.com/Kniggishood/ee72fe56e3a9917ce266b3608fd340f6)
+[Zum FAQ](FAQ.md)
 
 ## Download
 
-[![Download für Windows](https://img.shields.io/badge/latest-Windows%20x64-blue.svg)](https://github.com/amboss-mededu/ambulaunch-beta-releases/releases/download/v1.7.1/Ambulaunch-1.7.1-win-setup-x64-3182e4b2-98e1-4103-b4e1-e43185415c1e.exe)
+Aktuelle Version stets direkt aus dem **[Releases-Bereich](https://github.com/amboss-mededu/ambulaunch-beta-releases/releases/latest)** — dort die passende `.dmg` (macOS) oder `.exe` (Windows) auswählen.
 
-[![Download für macOS mit Intel/AMD Chip](https://img.shields.io/badge/latest-macOS%20x64%20(Intel|AMD)-white.svg)](https://github.com/amboss-mededu/ambulaunch-beta-releases/releases/download/v1.7.1/Ambulaunch-1.7.1-mac-x64-3182e4b2-98e1-4103-b4e1-e43185415c1e.dmg)
-[![Download für macOS mit Apple Chip](https://img.shields.io/badge/latest-macOS%20Apple%20Chip-white.svg)](https://github.com/amboss-mededu/ambulaunch-beta-releases/releases/download/v1.7.1/Ambulaunch-1.7.1-mac-arm64-3182e4b2-98e1-4103-b4e1-e43185415c1e.dmg)
+[![Download für macOS (Apple Silicon)](https://img.shields.io/badge/Download-macOS%20Apple%20Silicon-white.svg?logo=apple&logoColor=white)](https://github.com/amboss-mededu/ambulaunch-beta-releases/releases/latest)
+[![Download für macOS (Intel)](https://img.shields.io/badge/Download-macOS%20Intel-white.svg?logo=apple&logoColor=white)](https://github.com/amboss-mededu/ambulaunch-beta-releases/releases/latest)
+[![Download für Windows](https://img.shields.io/badge/Download-Windows%20x64-blue.svg?logo=windows&logoColor=white)](https://github.com/amboss-mededu/ambulaunch-beta-releases/releases/latest)
+
+![Aktuelle Version](https://img.shields.io/github/v/release/amboss-mededu/ambulaunch-beta-releases?display_name=tag&label=Aktuelle%20Version)
 
 ## Was kann Ambulaunch?
 
-### BFSB (Big Fat Search Box)
-- **Schneller Zugriff mit Hotkey**: Drücken Sie einfach `CMD + J` (Mac) oder `Strg + J` (Windows), um die BFSB sofort aufzurufen. Damit ist AMBOSS immer zur Hand, lenkt nicht ab und kann jederzeit bei Suchanfragen helfen. Sobald es aktiviert ist, wird das Such-Dashboard angezeigt, das bequem mit dem eingegebenen Begriff vorausgefüllt ist und sofortige und effiziente Suchvorgänge ermöglicht.
+### Schneller Zugriff mit Hotkey
+Drücken Sie einfach `Cmd + J` (macOS) oder `Strg + J` (Windows), um Ambulaunch sofort aufzurufen — der Hotkey lässt sich in den Einstellungen frei umbelegen. Damit ist AMBOSS immer zur Hand, lenkt nicht ab und steht bei Suchanfragen jederzeit zur Verfügung. Die Suchbox erscheint bequem mit dem eingegebenen Begriff vorausgefüllt und ermöglicht sofortige, effiziente Suchvorgänge.
 
-### Zusätzliche Funktionen/Roadmap
-- **Angepasste Vorschläge**: Ambulaunch ist nicht nur ein Suchtool, sondern bietet auch maßgeschneiderte Suchvorschläge und Deeplinks zu bestimmten Fachgebieten oder Interessenbereichen.
-- **Ähnlichen Antworten**: Ambulaunch findet nicht nur Ressourcen, sondern bietet auch relevante Antworten und Ressourcen, die auf dem Kontext Ihrer Anfrage basieren.
-- **Smart Assistant-Funktionen**: Sie funktioniert wie ein intelligenter Assistent, der schnelle Befehle für gängige Aufgaben liefert. Beispiele hierfür sind:
-  - `/Show reference lab values for liver` für eine Liste von Referenzwerten.
-  - `/Print AM checklist for migraine` zum Auflisten von Checklisten und Leitlinien.
-  - `/Open M3 study plan` für den Zugriff auf bestimmte Lernpläne.
+### Suche und KI-Modus
+- **Suche**: Vorschläge und Direkttreffer beim Tippen, basierend auf der AMBOSS-Inhaltsdatenbank.
+- **KI-Modus (Ask)**: Medizinische Frage formulieren und eine kuratierte, kontextuelle Antwort erhalten.
+
+### Komfortfunktionen
+- **Schwebendes Logo**: Ein dezentes AMBOSS-Logo bleibt auf dem Desktop sichtbar, ist klickbar und frei verschiebbar.
+- **Tray-Menü**: Direkter Zugriff auf Einstellungen, Sprache (Deutsch/Englisch) und Updates.
+- **Auto-Updates**: Ambulaunch hält sich selbst aktuell. Wer früher testen möchte, kann den Pre-Release-Kanal in den Einstellungen aktivieren.
+
+## Ambulaunch Pro
+
+Für Praxen und Kliniken mit weitergehenden Bedürfnissen gibt es **Ambulaunch Pro** — mit Spracheingabe, lokalen KI-Antworten auf dem Gerät und Bildanfragen per OCR. Anfragen an **hallo@amboss.com**.
 
 ## Verwendung
 
-Dieses Repository enthält die Releases von Ambulaunch BETA für einen einfachen öffentlichen Zugang und lokale Installation. Sie können die neueste Version, die für Ihr Betriebssystem geeignet ist, gerne herunterladen und testen.
-
-## Contributions
-
-While this is a publicly accessible repository, as an internal project we encourage contributions primarily from our team. If you're a team member and want to contribute:
-- Head to the [internal repo](https://github.com/amboss-mededu/Ambulaunch).
-- Fork it.
-- Change it.
-- Submit a pull request.
-
-We value your input and engagement to make Ambulaunch even better!
+Dieses Repository enthält die öffentlichen Releases der Standard-Edition von Ambulaunch für einen einfachen Zugang und lokale Installation. Beim ersten Start erfolgt eine einmalige AMBOSS-Anmeldung im integrierten Mini-Browser; die Sitzung bleibt anschließend dauerhaft aktiv.
 
 ## Lizenz | License
 
-Die Software ist unter einer proprietären Lizenz verfügbar. Die Weiterverbreitung und Verwendung in Quell- und Binärform, mit oder ohne Modifikation, ist ohne ausdrückliche vorherige schriftliche Genehmigung der AMBOSS GmbH nicht gestattet.
+Die Software ist unter einer proprietären Lizenz verfügbar. Die Weiterverbreitung und Verwendung in Quell- und Binärform, mit oder ohne Modifikation, ist ohne ausdrückliche vorherige schriftliche Genehmigung der AMBOSS SE nicht gestattet.
 
-The software is available under a proprietary license. Redistribution and use in source and binary forms, with or without modification, are not permitted without specific prior written permission from AMBOSS GmbH.
+The software is available under a proprietary license. Redistribution and use in source and binary forms, with or without modification, are not permitted without specific prior written permission from AMBOSS SE.
 
 Happy Launching! 🌟 und viel Spaß beim Starten! 🌕


### PR DESCRIPTION
## Summary

- README and FAQ rewritten to reflect v2 surfaces: rebindable hotkey, Settings window, floating logo, AI Mode (Ask), language switcher, auto-updates with pre-release opt-in, Pro upsell line.
- Download badges now link to /releases/latest instead of pinning v1.7.1. GitHub auto-resolves to whatever is flagged Latest, so README never needs touching on release.
- Version line uses shields.io dynamic GitHub badge — also no maintenance.
- v1-era "Smart Assistant" slash-command examples removed; they never shipped.
- FAQ link is now relative to the in-repo FAQ.md instead of an external gist.
- Internal-repo Contributions block dropped — wasn't useful and pointed at the v1 repo path.

## Test plan
- [ ] /releases/latest resolves to the current 2.5.1 stable release once it's marked Latest in the releases UI
- [ ] Aktuelle Version badge renders 2.5.1 (or whatever Latest is) via shields.io
- [ ] FAQ link from README opens FAQ.md in the same repo
- [ ] Demo gif still renders